### PR TITLE
increase z-index to get over sites that use very high numbers

### DIFF
--- a/ext/css/skin/popup-black.css
+++ b/ext/css/skin/popup-black.css
@@ -22,7 +22,7 @@
 
 #rikaichan-window { 
 	position: absolute;
-	z-index: 7777;
+	z-index: 999999999;
 	border: 1px solid #D0D0D0 !important;
 	padding: 4px;
 	background: #000000;

--- a/ext/css/skin/popup-blue.css
+++ b/ext/css/skin/popup-blue.css
@@ -22,7 +22,7 @@
 
 #rikaichan-window { 
 	position: absolute;
-	z-index: 7777;
+	z-index: 999999999;
 	border: 1px solid #D0D0D0 !important;
 	padding: 4px;
 	background: #5C73B8;

--- a/ext/css/skin/popup-light-blue.css
+++ b/ext/css/skin/popup-light-blue.css
@@ -22,7 +22,7 @@
 
 #rikaichan-window { 
 	position: absolute;
-	z-index: 7777;
+	z-index: 999999999;
 	border: 1px solid #D0D0D0 !important;
 	padding: 4px;
 	background: #E6F4FF;

--- a/ext/css/skin/popup-white-vl.css
+++ b/ext/css/skin/popup-white-vl.css
@@ -22,7 +22,7 @@
 
 #rikaichan-window { 
 	position: absolute;
-	z-index: 7777;
+	z-index: 999999999;
 	border: 1px solid #999 !important;
 	padding: 10px;
 	background: #FFF;

--- a/ext/css/skin/popup-yellow.css
+++ b/ext/css/skin/popup-yellow.css
@@ -22,7 +22,7 @@
 
 #rikaichan-window { 
 	position: absolute;
-	z-index: 7777;
+	z-index: 999999999;
 	border: 1px solid #D0D0D0 !important;
 	padding: 4px;
 	background: #FFFFBF;


### PR DESCRIPTION
For example, http://passpo.jp/page/pageProfile/ and then click on one of the crew to open the profile popup; it has a z-index of 99999.

I chose 999999999 which is not the maximum number that works but should be clear to anyone reading the code that it's an arbitrary extremely large number. (It's the largest number made only of 9s that would work.) Reference: http://softwareas.com/whats-the-maximum-z-index/

I made the change based on the chrome branch and tested it on Chrome. Looking at the diff in the merge request it seems it should work on master, but caveat emptor.